### PR TITLE
Patch/gamemode entities

### DIFF
--- a/code/Base/GamemodeSystem/Gamemode.cs
+++ b/code/Base/GamemodeSystem/Gamemode.cs
@@ -5,15 +5,9 @@ public abstract partial class BaseGamemode : Entity
 	[Net]
 	public IList<Client> Clients { get; set; }
 
-	[Property]
-	public string GamemodeId { get; set; }
-
 	public override void Spawn()
 	{
 		base.Spawn();
-
-		// for the inspector
-		Name = ClassName;
 
 		Transmit = TransmitType.Always;
 
@@ -41,14 +35,14 @@ public abstract partial class BaseGamemode : Entity
 	{
 		if ( !CanAddClient( cl ) )
 		{
-			Log.Debug( $"Sports: {cl.Name}'s was refused to join gamemode: {GamemodeId}" );
+			Log.Debug( $"Sports: {cl.Name}'s was refused to join gamemode: {Name}" );
 
 			return;
 		}
 
 		Clients.Add( cl );
 
-		Log.Debug( $"Sports: Adding {cl.Name} to gamemode: {GamemodeId}" );
+		Log.Debug( $"Sports: Adding {cl.Name} to gamemode: {Name}" );
 
 		var component = cl.GetGamemodeComponent();
 		component.Gamemode = this;
@@ -68,7 +62,7 @@ public abstract partial class BaseGamemode : Entity
 	{
 		Clients.Remove( cl );
 
-		Log.Debug( $"Sports: {cl.Name}' was removed from gamemode: {GamemodeId} with reason: {reason}" );
+		Log.Debug( $"Sports: {cl.Name}' was removed from gamemode: {Name} with reason: {reason}" );
 
 		var component = cl.GetGamemodeComponent();
 		component.Gamemode = null;

--- a/code/Base/GamemodeSystem/GamemodeOrb.cs
+++ b/code/Base/GamemodeSystem/GamemodeOrb.cs
@@ -37,8 +37,12 @@ public partial class GamemodeOrb : BaseTrigger
 		SetupPhysicsFromSphere( PhysicsMotionType.Keyframed, Vector3.Zero, 16f );
 		CollisionGroup = CollisionGroup.Trigger;
 
-		if ( ParticleSystemName is not null )
-			Particles.Create( ParticleSystemName, this );
+		_ = new ParticleSystemEntity
+		{
+			Position = Position,
+			ParticleSystemName = ParticleSystemName,
+			StartActive = true
+		};
 	}
 
 	protected override void OnDestroy()

--- a/code/Base/GamemodeSystem/GamemodeOrb.cs
+++ b/code/Base/GamemodeSystem/GamemodeOrb.cs
@@ -23,7 +23,7 @@ public partial class GamemodeOrb : BaseTrigger
 	protected void PostEntitiesSpawned()
 	{
 		LinkedGamemode = SportsGame.Instance?.GetGamemodeFromId( Gamemode );
-		if ( LinkedGamemode.IsValid )
+		if ( LinkedGamemode.IsValid() )
 			Log.Debug( "Orb: Linked to gamemode." );
 	}
 

--- a/code/Base/GamemodeSystem/GamemodeOrb.cs
+++ b/code/Base/GamemodeSystem/GamemodeOrb.cs
@@ -23,7 +23,7 @@ public partial class GamemodeOrb : BaseTrigger
 	protected void PostEntitiesSpawned()
 	{
 		LinkedGamemode = SportsGame.Instance?.GetGamemodeFromId( Gamemode );
-		if ( LinkedGamemode is not null )
+		if ( LinkedGamemode.IsValid )
 			Log.Debug( "Orb: Linked to gamemode." );
 	}
 
@@ -65,8 +65,8 @@ public partial class GamemodeOrb : BaseTrigger
 		}
 	}
 
-	[Event.Tick]
-	private void Tick()
+	[Event.Tick.Server]
+	private void ServerTick()
 	{
 		if ( !Debug.Enabled )
 			return;

--- a/code/Game.cs
+++ b/code/Game.cs
@@ -1,17 +1,11 @@
 global using Sandbox;
 global using Sandbox.UI;
 global using Sandbox.UI.Construct;
-global using Sandbox.Component;
 global using SandboxEditor;
-
 global using System;
 global using System.Collections.Generic;
-global using System.Linq;
 global using System.ComponentModel;
-global using System.Threading.Tasks;
-global using System.ComponentModel.DataAnnotations;
-
-using Sports.PartySystem;
+global using System.Linq;
 
 namespace Sports;
 
@@ -19,9 +13,9 @@ public partial class SportsGame : Game
 {
 	[Net] public IList<BaseGamemode> Gamemodes { get; set; }
 
-	public BaseGamemode GetGamemodeFromId( string id )
+	public BaseGamemode GetGamemodeFromId( string name )
 	{
-		return Gamemodes.FirstOrDefault( x => x.GamemodeId == id );
+		return Gamemodes.FirstOrDefault( x => x.Name.ToLower() == name );
 	}
 
 	public static SportsGame Instance => Current as SportsGame;

--- a/code/Game.cs
+++ b/code/Game.cs
@@ -15,7 +15,7 @@ public partial class SportsGame : Game
 
 	public BaseGamemode GetGamemodeFromId( string name )
 	{
-		return Gamemodes.FirstOrDefault( x => x.Name.ToLower() == name );
+		return Gamemodes.FirstOrDefault( x => x.Name.ToLower() == name.ToLower() );
 	}
 
 	public static SportsGame Instance => Current as SportsGame;

--- a/models/Dev/gamemode_orb.vmdl
+++ b/models/Dev/gamemode_orb.vmdl
@@ -10,20 +10,17 @@
 				children = 
 				[
 					{
-						_class = "RenderMeshFile"
-						filename = "models\\Dev\\dmx\\mesh\\gamemode_orb.dmx"
-						import_translation = [ 0.0, 0.0, 0.0 ]
-						import_rotation = [ 0.0, 0.0, 0.0 ]
-						import_scale = 1.0
-						align_origin_x_type = "None"
-						align_origin_y_type = "None"
-						align_origin_z_type = "None"
+						_class = "RenderPrimitiveSphere"
+						name = "orb"
 						parent_bone = ""
-						import_filter = 
-						{
-							exclude_by_default = false
-							exception_list = [  ]
-						}
+						material_name = "dev/helper/testgrid.vmat"
+						origin = [ 0.0, 0.0, 0.0 ]
+						angles = [ 0.0, 0.0, 0.0 ]
+						max_u = 1.0
+						max_v = 1.0
+						radius = 16.0
+						segments_u = 16
+						segments_v = 16
 					},
 				]
 			},
@@ -33,13 +30,7 @@
 				[
 					{
 						_class = "DefaultMaterialGroup"
-						remaps = 
-						[
-							{
-								from = "materials/dev/reflectivity_30.vmat"
-								to = "debug/debugempty.vmat"
-							},
-						]
+						remaps = [  ]
 						use_global_default = false
 						global_default_material = ""
 					},
@@ -57,7 +48,7 @@
 						collision_interact_as = ""
 						collision_interact_with = ""
 						collision_interact_exclude = ""
-						radius = 30.0
+						radius = 16.0
 						center = [ 0.0, 0.0, 0.0 ]
 					},
 				]

--- a/particles/gamemode_orb/orb.vpcf
+++ b/particles/gamemode_orb/orb.vpcf
@@ -2,6 +2,77 @@
 {
 	_class = "CParticleSystemDefinition"
 	m_nBehaviorVersion = 10
+	m_nMaxParticles = 1
+	m_flConstantRadius = 1.0
+	m_controlPointConfigurations = 
+	[
+		{
+			m_name = "preview"
+		},
+	]
+	m_Emitters = 
+	[
+		{
+			_class = "C_OP_InstantaneousEmitter"
+			m_nParticlesToEmit = 
+			{
+				m_nType = "PF_TYPE_LITERAL"
+				m_nMapType = "PF_MAP_TYPE_DIRECT"
+				m_flLiteralValue = 1.0
+				m_nControlPoint = 0
+				m_nScalarAttribute = 3
+				m_nVectorAttribute = 6
+				m_nVectorComponent = 0
+				m_flRandomMin = 0.0
+				m_flRandomMax = 1.0
+				m_nRandomMode = "PF_RANDOM_MODE_CONSTANT"
+				m_flLOD0 = 0.0
+				m_flLOD1 = 0.0
+				m_flLOD2 = 0.0
+				m_flLOD3 = 0.0
+				m_flNoiseOutputMin = 0.0
+				m_flNoiseOutputMax = 1.0
+				m_flNoiseScale = 0.1
+				m_vecNoiseOffsetRate = [ 0.0, 0.0, 0.0 ]
+				m_flNoiseOffset = 0.0
+				m_nNoiseOctaves = 1
+				m_nNoiseTurbulence = "PF_NOISE_TURB_NONE"
+				m_nNoiseType = "PF_NOISE_TYPE_PERLIN"
+				m_nNoiseModifier = "PF_NOISE_MODIFIER_NONE"
+				m_flNoiseTurbulenceScale = 1.25
+				m_flNoiseTurbulenceMix = 0.5
+				m_flNoiseImgPreviewScale = 1.0
+				m_bNoiseImgPreviewLive = true
+				m_nInputMode = "PF_INPUT_MODE_CLAMPED"
+				m_flMultFactor = 1.0
+				m_flInput0 = 0.0
+				m_flInput1 = 1.0
+				m_flOutput0 = 0.0
+				m_flOutput1 = 1.0
+				m_nBiasType = "PF_BIAS_TYPE_STANDARD"
+				m_flBiasParameter = 0.0
+				m_Curve = 
+				{
+					m_spline = [  ]
+					m_tangents = [  ]
+					m_vDomainMins = [ 0.0, 0.0 ]
+					m_vDomainMaxs = [ 0.0, 0.0 ]
+				}
+			}
+		},
+	]
+	m_Initializers = 
+	[
+		{
+			_class = "C_INIT_CreateWithinSphere"
+		},
+	]
+	m_Operators = 
+	[
+		{
+			_class = "C_OP_EndCapTimedDecay"
+		},
+	]
 	m_Renderers = 
 	[
 		{
@@ -12,12 +83,6 @@
 					m_model = resource:"models/dev/gamemode_orb.vmdl"
 				},
 			]
-		},
-	]
-	m_controlPointConfigurations = 
-	[
-		{
-			m_name = "preview"
 		},
 	]
 }


### PR DESCRIPTION
I've just quickly patched up how gamemode entities link together. The orb now has a proper particle system that'll get spawned in-game and show up in-hammer and it references a gamemode entity via its targetname.

Do note that for some reason the gamemode entity targetname gets automatically capitalized in-game, so there's a temp hack with ToLower() on the linking process. It should be fine though, as long as we don't have SUPER ambiguous gamemode entity names that only differ in capitalization.